### PR TITLE
Backup database with cloud (Google Drive)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test.py
 .venv/
 *.egg-info
 dist
+cred*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__/
 *.db
-test.py
+# test.py
 .venv/
 *.egg-info
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__/
 *.db
-# test.py
+test.py
 .venv/
 *.egg-info
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ test.py
 .venv/
 *.egg-info
 dist
-cred*.json
+*.json

--- a/README.md
+++ b/README.md
@@ -27,5 +27,33 @@ texpass
 ```
 The application can be quit by pressing the escape key.
 
+### Backup with Google Drive
+The ability to backup your database has been added recently. **There are a couple pitfalls at the moment so use with caution.**
+
+This only works with Google Drive at the moment. Follow the steps below to enable it:
+1. Create a new Google Cloud project by following the steps [here](https://developers.google.com/workspace/guides/create-project#project).
+2. Enable [Google Drive API](https://developers.google.com/workspace/drive/api/quickstart/python#enable_the_api)
+3. Configure OAuth consent screen ([steps](https://developers.google.com/workspace/drive/api/quickstart/python#configure_the_oauth_consent_screen))
+    - If following above steps, you may not be able to select "Internal" audience. Select "External" audience if that is the case.
+    - Go to [Audience](https://console.cloud.google.com/auth/audience) for your project and in test users section, add a test user with the email you want to use for Drive backups
+4. Authorize credentials for the application by following these [steps](https://developers.google.com/workspace/drive/api/quickstart/python#authorize_credentials_for_a_desktop_application)
+    - Set application type to "desktop app".
+    - Select "Download JSON" and name it to `creds.json`
+5. Move this file to wherever you call texpass from in the command line
+    - Let's say you call it from `/home/username/Documents/texpass/` (Linux) (if you have already used the app before you would notice a `passwords.db` file there), move it to that folder
+6. Run the below command and follow the steps in there
+```sh
+python3 -m texpass --cloud
+```
+7. Create a folder named "texpass" in your Google Drive
+
+Now when entering the application, using `Ctrl+S` allows you to either upload your database file to Drive under texpass folder, or download it from there.
+
+**CAUTION: Since uploading/downloading overwrites the database file, make sure to upload after making changes, and download as soon as possible if changes were made on another device and uploaded to Drive, to avoid version conflicts/overwrites**
+
+**CAUTION 2: creds.json and token.json files are secret files that should NEVER be shared and should be stored securely.**
+
+These were the pitfalls. Future updates will work on enhancing the security and making the process easier/more automatic. 
+
 ### Contributing
 Feel free to report any bugs or additional features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "texpass"
-version = "2.1.0"
+version = "2.1.1"
 authors = [
   { name="Rinceri", email="rinceri@protonmail.com" },
 ]
@@ -21,7 +21,10 @@ dependencies = [
     "textual>3.5.0",
     "argon2-cffi",
     "pyperclip",
-    "cryptography"
+    "cryptography",
+    "google-api-python-client",
+    "google-auth-httplib2",
+    "google-auth-oauthlib"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ textual-dev
 argon2-cffi
 pyperclip
 cryptography
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib

--- a/src/texpass/exceptions/exceptions.py
+++ b/src/texpass/exceptions/exceptions.py
@@ -12,3 +12,13 @@ class WrongPassword(Exception):
 
 class InvalidArguments(Exception):
     pass
+
+# drive sync exceptions
+class DriveException(Exception):
+    pass
+
+class FolderNotFound(Exception):
+    pass
+
+class DatabaseNotFound(Exception):
+    pass

--- a/src/texpass/helper/wsgi_server.py
+++ b/src/texpass/helper/wsgi_server.py
@@ -1,0 +1,72 @@
+import wsgiref.simple_server
+import wsgiref.util
+
+from google_auth_oauthlib.flow import Flow
+
+# taken from https://github.com/googleapis/google-auth-library-python-oauthlib/blob/main/google_auth_oauthlib/flow.py
+
+class LocalServer:
+    def __init__(self, flow: Flow):
+        self.flow = flow
+        self.local_server = None
+        self.wsgi_app = _RedirectWSGIApp()
+        
+
+    def get_auth_url(self) -> str:
+        """
+        Get auth URL. Make sure to run server, as a server has been made
+        """
+        host = "localhost"
+        port = 8080
+
+        self.local_server: wsgiref.simple_server.WSGIServer = wsgiref.simple_server.make_server(
+            host,
+            port,
+            self.wsgi_app
+        )
+
+        self.flow.redirect_uri = f"http://{host}:{port}"
+        auth_url, _ = self.flow.authorization_url()
+
+        return auth_url
+    
+    def run_local_server(self):
+        try:
+            self.local_server.handle_request()
+
+            # Note: using https here because oauthlib is very picky that
+            # OAuth 2.0 should only occur over https.
+            auth_response = self.wsgi_app.last_request_uri.replace("http", "https")
+            self.flow.fetch_token(authorization_response = auth_response)
+
+        finally:
+            self.local_server.server_close()
+
+        return self.flow.credentials
+
+
+
+class _RedirectWSGIApp(object):
+    """WSGI app to handle the authorization redirect.
+
+    Stores the request URI and displays the given success message.
+    """
+
+    def __init__(self):
+        self.last_request_uri = None
+        self._success_message = "The authentication flow has completed. You may close this window."
+
+    def __call__(self, environ, start_response):
+        """WSGI Callable.
+
+        Args:
+            environ (Mapping[str, Any]): The WSGI environment.
+            start_response (Callable[str, list]): The WSGI start_response
+                callable.
+
+        Returns:
+            Iterable[bytes]: The response body.
+        """
+        start_response("200 OK", [("Content-type", "text/plain; charset=utf-8")])
+        self.last_request_uri = wsgiref.util.request_uri(environ)
+        return [self._success_message.encode("utf-8")]

--- a/src/texpass/model/drive_sync.py
+++ b/src/texpass/model/drive_sync.py
@@ -2,6 +2,7 @@ import os.path
 import io
 
 from google.auth.transport.requests import Request
+from google.auth.credentials import TokenState
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
@@ -9,10 +10,12 @@ from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 from googleapiclient.errors import HttpError
 
 from texpass.exceptions.exceptions import DriveException, FolderNotFound, DatabaseNotFound
+from texpass.helper.wsgi_server import LocalServer
 
 class DriveSync:
-    SCOPES = ["https://www.googleapis.com/auth/drive"]
-
+    """
+    Should only be instantiated through OAuthDrive
+    """
     def __init__(self, creds: Credentials, parent_folder_name: str = "texpass"):
         self.creds = creds
         self.parent_name = parent_folder_name
@@ -20,30 +23,6 @@ class DriveSync:
         # NOTE may not work
         self.parent_id = self._get_parent_id()
     
-    @classmethod
-    def from_oauth(cls, parent_folder_name: str = "texpass"):
-        creds = None
-        # The file token.json stores the user's access and refresh tokens, and is
-        # created automatically when the authorization flow completes for the first
-        # time.
-        if os.path.exists("token.json"):
-            creds = Credentials.from_authorized_user_file("token.json", DriveSync.SCOPES)
-
-        # If there are no (valid) credentials available, let the user log in using creds.json
-        if not creds or not creds.valid:
-            if creds and creds.expired and creds.refresh_token:
-                creds.refresh(Request())
-            else:
-                flow = InstalledAppFlow.from_client_secrets_file(
-                    "creds.json", DriveSync.SCOPES
-                )
-                creds = flow.run_local_server(port=0)
-            # Save the credentials for the next run
-            with open("token.json", "w") as token:
-                token.write(creds.to_json())
-
-        return cls(creds, parent_folder_name)
-
     def _get_files(self):
         service = build("drive", "v3", credentials = self.creds)
         return service.files()
@@ -142,6 +121,98 @@ class DriveSync:
             password_file.write(file.getvalue())
 
 
+class OAuthDrive:
+    """
+    Get DriveSync class using this
+    
+    Workflow:
+    1. Check creds exist
+    2. If they do, get drive instance
+    3. If they don't, get flow url
+    3.1. Run server to process auth flow
+    3.2 Get drive instance
+    """
+
+    SCOPES = ["https://www.googleapis.com/auth/drive"]
+
+    def __init__(self, access_token_file: str):
+        self.access_file = access_token_file
+        self.flow = None
+        # since we use a local web server to listen for google auth server
+        self.redirect_uri = "http://localhost:8080"
+        self.creds = None
+
+    def creds_exist(self) -> bool:
+        """
+        Returns True if access token exists and is valid. Otherwise returns false
+
+        If valid, can successfully create DriveSync object
+        """
+        # check if access token exists
+        if os.path.exists(self.access_file):
+            self.creds = Credentials.from_authorized_user_file(self.access_file, OAuthDrive.SCOPES)
+        else:
+            return False
+
+        if self.creds.token_state == TokenState.INVALID:
+            # if invalid, and can be refreshed, attempt to refresh
+            if self.creds.expired and self.creds.refresh_token:
+                try:
+                    self.creds.refresh(Request())
+                except:
+                    # attempt failed
+                    return False
+                else:
+                    # write to creds file after refreshing
+                    self._write_access_token_to_file()
+                    return True
+            return False
+
+        # creds token state is valid
+        return True
+    
+    def get_flow_url(self, auth_client_file: str) -> str:
+        """
+        Returns URL to authenticate client and get access token
+
+        Local server has started running. Make sure to run_server after
+        """
+        self.flow = InstalledAppFlow.from_client_secrets_file(
+            auth_client_file, OAuthDrive.SCOPES,
+            redirect_uri = self.redirect_uri
+        )
+
+        self.local_server = LocalServer(self.flow)
+
+        return self.local_server.get_auth_url()
+    
+    def run_server(self):
+        """
+        Runs local server to get oauth access token. Saves it internally
+
+        Make sure to run get_flow_url before this to get a Flow object
+        """
+        self.creds = self.local_server.run_local_server()
+        self._write_access_token_to_file()
+
+    def _write_access_token_to_file(self):
+        with open(self.access_file, "w") as token:
+            token.write(self.creds.to_json())
+
+    def get_drive_instance(self, parent_folder_name: str = "texpass") -> DriveSync:
+        """
+        Create DriveSync object. Make sure to have valid creds have been loaded
+        """
+        return DriveSync(self.creds, parent_folder_name)
+
+
 if __name__ == "__main__":
-    drive = DriveSync.from_oauth()
+    oauthdrive = OAuthDrive("token.json")
+
+    if not oauthdrive.creds_exist():
+        url = oauthdrive.get_flow_url("creds.json")
+        print(url)
+        oauthdrive.run_server()
+    
+    drive = oauthdrive.get_drive_instance()
     drive.fetch()

--- a/src/texpass/model/drive_sync.py
+++ b/src/texpass/model/drive_sync.py
@@ -1,4 +1,5 @@
 import os.path
+import io
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
@@ -7,7 +8,7 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 from googleapiclient.errors import HttpError
 
-import io
+from texpass.exceptions.exceptions import DriveException, FolderNotFound, DatabaseNotFound
 
 class DriveSync:
     SCOPES = ["https://www.googleapis.com/auth/drive"]
@@ -140,15 +141,6 @@ class DriveSync:
         with open('passwords.db', 'wb') as password_file:
             password_file.write(file.getvalue())
 
-
-class DriveException(Exception):
-    pass
-
-class FolderNotFound(Exception):
-    pass
-
-class DatabaseNotFound(Exception):
-    pass
 
 if __name__ == "__main__":
     drive = DriveSync.from_oauth()

--- a/src/texpass/screens/edit_entry.py
+++ b/src/texpass/screens/edit_entry.py
@@ -50,7 +50,8 @@ class EditEntryScreen(ModalScreen):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "cancel":
             self.app.pop_screen()
-
+            return
+        
         username = self.query_one("#edited_uname").value
         website = self.query_one("#edited_web").value
         password = self.query_one("#edited_pword").value

--- a/src/texpass/screens/new_entry.py
+++ b/src/texpass/screens/new_entry.py
@@ -44,6 +44,7 @@ class NewEntryScreen(ModalScreen):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "cancel":
             self.app.pop_screen()
+            return
 
         username = self.query_one("#usname").value
         website = self.query_one("#webs").value

--- a/src/texpass/screens/sync_cloud.py
+++ b/src/texpass/screens/sync_cloud.py
@@ -4,6 +4,8 @@ from textual.screen import ModalScreen
 from textual.app import ComposeResult
 
 from texpass.model.drive_sync import DriveSync
+from texpass.controller.table_controller import TableController
+
 
 class SyncCloudScreen(ModalScreen):
     """
@@ -35,6 +37,13 @@ class SyncCloudScreen(ModalScreen):
             if event.button.id == "drive_upload":
                 drive.upload()
                 self.query_one("#status", Static).update("File has been uploaded under texpass folder")
+                self.dismiss(False)
             elif event.button.id == "drive_download":
                 drive.fetch()
-                self.query_one("#status", Static).update("File has been downloaded. TEMP: RESTART CLIENT")
+                self.query_one("#status", Static).update("File has been downloaded.")
+                self.dismiss(True)
+
+
+# TODO
+# refresh table after downloading from drive
+# handle errors

--- a/src/texpass/screens/sync_cloud.py
+++ b/src/texpass/screens/sync_cloud.py
@@ -3,7 +3,7 @@ from textual.widgets import Button, Static
 from textual.screen import ModalScreen
 from textual.app import ComposeResult
 
-from texpass.model.drive_sync import DriveSync
+from texpass.model.drive_sync import OAuthDrive
 from texpass.exceptions.exceptions import *
 
 
@@ -32,8 +32,14 @@ class SyncCloudScreen(ModalScreen):
         if event.button.id == "cancel":
             self.app.pop_screen()
             return
+
+        auth = OAuthDrive("token.json")
+        if not auth.creds_exist():
+            self.query_one("#status", Static).update("Please setup cloud syncing with --cloud option when starting the app")
+            return
+
         try:
-            drive = DriveSync.from_oauth()
+            drive = auth.get_drive_instance()
 
             if event.button.id == "drive_upload":
                 drive.upload()
@@ -45,7 +51,3 @@ class SyncCloudScreen(ModalScreen):
                 self.dismiss(True)
         except Exception as e:
             self.query_one("#status", Static).update(f"An error occured: {e}")
-
-
-# TODO
-# handle errors

--- a/src/texpass/screens/sync_cloud.py
+++ b/src/texpass/screens/sync_cloud.py
@@ -1,0 +1,40 @@
+from textual.containers import Vertical
+from textual.widgets import Button, Static
+from textual.screen import ModalScreen
+from textual.app import ComposeResult
+
+from texpass.model.drive_sync import DriveSync
+
+class SyncCloudScreen(ModalScreen):
+    """
+    Screen for syncing google drive database to local
+    """
+    CSS_PATH = "../styles/modal_screens.tcss"
+    BINDINGS = [
+        ("escape", "app.pop_screen", "Pop screen")
+    ]
+
+    def __init__(self):
+        super().__init__(classes="centered", id="new_modal")
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="new_entry_vertical"):
+            yield Static("Sync with Google Drive")
+            yield Static(id = "status", classes="entrystatic")
+            with Vertical():
+                yield Button("Upload to Drive", id = "drive_upload", classes = "submit entrybutton")
+                yield Button("Download from Drive", id = "drive_download", classes = "submit entrybutton")
+                yield Button("Cancel", id = "cancel", classes = "entrybutton")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.app.pop_screen()
+        else:
+            drive = DriveSync.from_oauth()
+
+            if event.button.id == "drive_upload":
+                drive.upload()
+                self.query_one("#status", Static).update("File has been uploaded under texpass folder")
+            elif event.button.id == "drive_download":
+                drive.fetch()
+                self.query_one("#status", Static).update("File has been downloaded. TEMP: RESTART CLIENT")

--- a/src/texpass/screens/sync_cloud.py
+++ b/src/texpass/screens/sync_cloud.py
@@ -4,7 +4,7 @@ from textual.screen import ModalScreen
 from textual.app import ComposeResult
 
 from texpass.model.drive_sync import DriveSync
-from texpass.controller.table_controller import TableController
+from texpass.exceptions.exceptions import *
 
 
 class SyncCloudScreen(ModalScreen):
@@ -31,7 +31,8 @@ class SyncCloudScreen(ModalScreen):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "cancel":
             self.app.pop_screen()
-        else:
+            return
+        try:
             drive = DriveSync.from_oauth()
 
             if event.button.id == "drive_upload":
@@ -42,8 +43,9 @@ class SyncCloudScreen(ModalScreen):
                 drive.fetch()
                 self.query_one("#status", Static).update("File has been downloaded.")
                 self.dismiss(True)
+        except Exception as e:
+            self.query_one("#status", Static).update(f"An error occured: {e}")
 
 
 # TODO
-# refresh table after downloading from drive
 # handle errors

--- a/src/texpass/screens/table.py
+++ b/src/texpass/screens/table.py
@@ -64,4 +64,10 @@ class TableScreen(Screen):
         self.screen_switcher.push_delete()
 
     def action_sync_cloud(self) -> None:
-        self.app.push_screen(SyncCloudScreen())
+        def refresh_table(fetched: bool):
+            if fetched:
+                self.controller.populate_internal_table()
+                self.table.clear()
+                self.table.fill_table()
+
+        self.app.push_screen(SyncCloudScreen(), refresh_table)

--- a/src/texpass/screens/table.py
+++ b/src/texpass/screens/table.py
@@ -6,6 +6,7 @@ from textual.binding import Binding
 from texpass.widgets.data_table import MyTable
 from texpass.widgets.search_input import SearchInput
 from texpass.screens.new_entry import NewEntryScreen
+from texpass.screens.sync_cloud import SyncCloudScreen
 from texpass.controller.screen_controller import ScreenController
 from texpass.controller.table_controller import TableController
 
@@ -19,6 +20,7 @@ class TableScreen(Screen):
         Binding("ctrl+e", "edit_entry", "Edit entry", priority=True),
         Binding("ctrl+c", "copy", "Copy password", priority=True),
         Binding("ctrl+d", "delete_entry", "Delete entry", priority=True),
+        Binding("ctrl+s", "sync_cloud", "Sync with Drive", priority=True),
         Binding("escape", "logout", "Log out", priority=True),
         Binding("ctrl+delete", "delete_profile", "Delete profile", priority=True),
     ]
@@ -60,3 +62,6 @@ class TableScreen(Screen):
 
     def action_delete_profile(self) -> None:
         self.screen_switcher.push_delete()
+
+    def action_sync_cloud(self) -> None:
+        self.app.push_screen(SyncCloudScreen())

--- a/src/texpass/setup_cloud.py
+++ b/src/texpass/setup_cloud.py
@@ -1,0 +1,30 @@
+from texpass.model.drive_sync import OAuthDrive
+import os.path
+
+
+def main():
+    ACCESS_FILE = "token.json"
+    CREDS_FILE = "creds.json"
+
+    if not os.path.exists(CREDS_FILE):
+        print("ERROR: Cannot find file named creds.json")
+        print("Follow the guide in the project's README to get client credentials to proceed")
+        exit(1)
+    
+    auth = OAuthDrive(ACCESS_FILE)
+
+    if auth.creds_exist():
+        print("No changes made. All credentials are valid.")
+        exit()
+    
+    # creds are invalid
+    url = auth.get_flow_url(CREDS_FILE)
+
+    print("=== Visit this link to authorize your account: ===")
+    print(url)
+    print("=== ===")
+
+    auth.run_server()
+
+    print("=== ===")
+    print("Setup is complete. All credentials are valid.")

--- a/src/texpass/start.py
+++ b/src/texpass/start.py
@@ -1,4 +1,5 @@
 from textual.app import App
+import argparse
 
 from texpass.controller.screen_controller import ScreenController
 
@@ -14,11 +15,20 @@ def main():
     Creates the App and runs it
     """
     from texpass import setup_app
+    from texpass import setup_cloud
 
     setup_app.setup_database()
 
-    app = MainApp()
-    app.run()
+    parser = argparse.ArgumentParser(description="TUI Password manager")
+
+    parser.add_argument('-c', '--cloud', action="store_true")
+    args = parser.parse_args()
+
+    if args.cloud:
+        setup_cloud.main()
+    else:
+        app = MainApp()
+        app.run()
 
 if __name__ == "__main__":
     main()

--- a/src/texpass/styles/modal_screens.tcss
+++ b/src/texpass/styles/modal_screens.tcss
@@ -56,6 +56,15 @@ ModalScreen SubmitInput {
     margin: 0 1;
 }
 
+Vertical > .entrybutton {
+    width: 100%;
+    height: auto;
+}
+
+Vertical {
+    height: auto;
+}
+
 .entrystatic {
     content-align: center middle;
     text-style: bold;

--- a/test.py
+++ b/test.py
@@ -3,228 +3,153 @@ import os.path
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import build, Resource
+from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 from googleapiclient.errors import HttpError
-import webbrowser
+
 import io
 
-# need creds.json to work
+class DriveSync:
+    SCOPES = ["https://www.googleapis.com/auth/drive"]
 
-# If modifying these scopes, delete the file token.json.
-SCOPES = ["https://www.googleapis.com/auth/drive"]
-
-
-def main_test():
-    """Shows basic usage of the Drive v3 API.
-    Prints the names and ids of the first 10 files the user has access to.
-    """
-    webbrowser.register("brave", None, webbrowser.BackgroundBrowser("/usr/bin/brave"))
-
-    creds = None
-    # The file token.json stores the user's access and refresh tokens, and is
-    # created automatically when the authorization flow completes for the first
-    # time.
-    if os.path.exists("token.json"):
-        creds = Credentials.from_authorized_user_file("token.json", SCOPES)
-    # If there are no (valid) credentials available, let the user log in.
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(
-                "creds.json", SCOPES
-            )
-            creds = flow.run_local_server(port=0, browser="brave")
-    # Save the credentials for the next run
-    with open("token.json", "w") as token:
-        token.write(creds.to_json())
-
-    try:
-        # create drive api client
-        service = build("drive", "v3", credentials=creds)
-        files = []
-        page_token = None
-        while True:
-            # pylint: disable=maybe-no-member
-            response = (
-                service.files()
-                .list(
-                    pageSize = 10,
-                    q="visibility = 'limited'",
-                    spaces="drive",
-                    fields="nextPageToken, files(id, name)",
-                    pageToken=page_token,
-                )
-                .execute()
-            )
-            for file in response.get("files", []):
-                # Process change
-                print(f'Found file: {file.get("name")}, {file.get("id")}')
-            files.extend(response.get("files", []))
-            page_token = response.get("nextPageToken", None)
-            # if page_token is None:
-            break
-
-    except HttpError as error:
-        print(f"An error occurred: {error}")
-        files = None
-
-def main():
-    webbrowser.register("brave", None, webbrowser.BackgroundBrowser("/usr/bin/brave"))
-
-    creds = None
-    # The file token.json stores the user's access and refresh tokens, and is
-    # created automatically when the authorization flow completes for the first
-    # time.
-    if os.path.exists("token.json"):
-        creds = Credentials.from_authorized_user_file("token.json", SCOPES)
-    # If there are no (valid) credentials available, let the user log in.
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(
-                "creds.json", SCOPES
-            )
-            creds = flow.run_local_server(port=0, browser="brave")
-    # Save the credentials for the next run
-    with open("token.json", "w") as token:
-        token.write(creds.to_json())
-
-    folder = get_folder(creds)
-    print("Uploading to folder ", folder)
-
-    upload_database(creds, [folder])
-
-    fetch_database(creds, folder)
-    
-
-def overwrite_database(creds: Credentials, parent: str = None):
-    """
-    Overwrite the database if already exists
-    """
-    try:
-        service = build("drive", "v3", credentials = creds)
+    def __init__(self, creds: Credentials, parent_folder_name: str = "texpass"):
+        self.creds = creds
+        self.parent_name = parent_folder_name
         
-        query = f"name = 'passwords.db' and trashed = false and '{parent}' in parents"
-        result: dict = (
-            service.files()
-            .list(fields = "files(id)", q = query)
+        # NOTE may not work
+        self.parent_id = self._get_parent_id()
+    
+    @classmethod
+    def from_oauth(cls, parent_folder_name: str = "texpass"):
+        creds = None
+        # The file token.json stores the user's access and refresh tokens, and is
+        # created automatically when the authorization flow completes for the first
+        # time.
+        if os.path.exists("token.json"):
+            creds = Credentials.from_authorized_user_file("token.json", DriveSync.SCOPES)
+
+        # If there are no (valid) credentials available, let the user log in using creds.json
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    "creds.json", DriveSync.SCOPES
+                )
+                creds = flow.run_local_server(port=0)
+            # Save the credentials for the next run
+            with open("token.json", "w") as token:
+                token.write(creds.to_json())
+
+        return cls(creds, parent_folder_name)
+
+    def _get_files(self):
+        service = build("drive", "v3", credentials = self.creds)
+        return service.files()
+    
+    def _get_file_list(self, query: str, fields: str = "files(id)") -> dict:
+        return (
+            self._get_files()
+            .list(fields = fields, q = query)
             .execute()
         )
 
-        if not result.get('files'):
-            print("Could not find anything")
-            return False
-    
-        if os.path.exists('passwords.db'):
-            media = MediaFileUpload("passwords.db")
-        else:
-            print("File does not exist, skipping...")
-            return False
-        service.files().update(fileId = result.get('files')[0]['id'], media_body = media).execute()
-
-        print("Done!")
-        return True
-        
-
-    except HttpError as error:
-        print(f"error: {error}")
-
-
-
-def upload_database(creds: Credentials, parents: list[str] = None):
-    """
-    Inserts passwords.db into a folder called "texpass" on Google Drive
-
-    Ensure creds are loaded before calling this
-    """
-
-    if overwrite_database(creds, parents[0]):
-        return
-
-    try:
-        service = build("drive", "v3", credentials = creds)
-        
-        file_metadata = {"name": "passwords.db", "parents": parents}
-        if os.path.exists('passwords.db'):
-            media = MediaFileUpload("passwords.db")
-        else:
-            print("File does not exist, skipping...")
-            return False
-
-        file = service.files().create(body=file_metadata, media_body=media, fields='id').execute()
-        print(f"file id: {file.get("id")}")
-        
-
-    except HttpError as error:
-        print(f"error: {error}")
-
-
-def get_folder(creds: Credentials, name: str = "texpass") -> str:
-    """
-    Get file ID for the folder to save the passwords.db file to
-    """
-    try:
-        service: Resource = build("drive", "v3", credentials=creds)
-        
+    def _get_parent_id(self) -> str:
+        """
+        Get file id for parent folder. Raises FolderNotFound if not found
+        """
         # get a folder which is not shared with anyone or domain
         # make sure its not a trash folder
-        results: dict = (
-            service.files()
-            .list(fields = "files(parents, id)", q = f"mimeType = 'application/vnd.google-apps.folder' and name = '{name}' and trashed = false")
-            .execute()
-        )
-
+        query = f"mimeType = 'application/vnd.google-apps.folder' and name = '{self.parent_name}' and trashed = false"
+        results = self._get_file_list(query)
+        
         folders = results.get("files")
-        
+
+        # folders should contain a list of elements, if none, will evaluate to false
         if not folders:
-            print("No folder found.")
-            return
+            raise FolderNotFound(f"Folder with name {self.parent_name} could not be found")
         
+        # get the first instance of the folder, and return its ID
         return folders[0]['id']
-    
-    except HttpError as error:
-        # TODO(developer) - Handle errors from drive API.
-        print(f"An error occurred: {error}")
 
-
-def fetch_database(creds: Credentials, parent: str):
-    try:
-        service = build("drive", "v3", credentials=creds)
-        query = f"name = 'passwords.db' and trashed = false and '{parent}' in parents"
-        result: dict = (
-            service.files()
-            .list(fields = "files(id)", q = query)
-            .execute()
-        )
-
-        if not result.get('files'):
-            print("No file exists. Upload before fetching")
-            return
+    def upload(self) -> str:
+        """
+        Inserts passwords.db into parent folder on Google Drive
+        
+        When successful, returns id of uploaded file
+        """
+        # check if passwords.db file exists locally
+        if os.path.exists('passwords.db'):
+            media = MediaFileUpload("passwords.db")
         else:
-            fileId = result.get('files')[0]['id']
+            raise DatabaseNotFound("File passwords.db was not found")
+
+        try:
+            try:
+                fileId = self._get_cloud_save()
     
-        results = service.files().get_media(fileId = fileId)
-        file = io.BytesIO()
+                # file exists in cloud, just overwrite it
+                file = self._get_files().update(fileId = fileId, media_body = media, fields = 'id').execute()
+            except DatabaseNotFound:
+                # file doesn't exist, upload local to cloud
+                file_metadata = {"name": "passwords.db", "parents": [self.parent_id]}
+                file = self._get_files().create(body = file_metadata, media_body = media, fields = 'id').execute()
+            
+        except HttpError as e:
+            raise DriveException(e)
+        else:
+            return file.get('id')
 
-        downloader = MediaIoBaseDownload(file, results)
-        done = False
+    def _get_cloud_save(self) -> str:
+        """
+        Get file id of passwords.db if it exists in cloud under parent folder and not in trash
 
-        while done is False:
-            status, done = downloader.next_chunk()
-            print(f"Download {int(status.progress() * 100)}.")
+        Raises DatabaseNotFound if not found
+        """
+        query = f"name = 'passwords.db' and trashed = false and '{self.parent_id}' in parents"
+        files = self._get_file_list(query)
 
-    except HttpError as error:
-        print(f"An error occurred: {error}")
-        file = None
-        return
+        if files.get('files'):
+            return files.get('files')[0]['id']
+        else:
+            raise DatabaseNotFound("File passwords.db was not found in cloud")
 
-    with open('passwords.db', 'wb') as test:
-        test.write(file.getvalue())
+    def fetch(self):
+        """
+        Download database from cloud, under parent folder and not in trash
 
-    return file
+        If not found, raises DatabaseNotFound
+        """
+        try:
+            # if database not found, let it bubble up to the caller
+            fileId = self._get_cloud_save()
+            results = self._get_files().get_media(fileId = fileId)
+            file = io.BytesIO()
+
+            downloader = MediaIoBaseDownload(file, results)
+            done = False
+
+            while done is False:
+                _, done = downloader.next_chunk()
+
+        except HttpError as e:
+            raise DriveException(e)
+        
+        # write to passwords.db file as bytes
+        # should completely overwrite it if already exists
+        with open('passwords.db', 'wb') as password_file:
+            password_file.write(file.getvalue())
+
+
+class DriveException(Exception):
+    pass
+
+class FolderNotFound(Exception):
+    pass
+
+class DatabaseNotFound(Exception):
+    pass
 
 if __name__ == "__main__":
-  main()
+    drive = DriveSync.from_oauth()
+    drive.fetch()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,230 @@
+import os.path
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build, Resource
+from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
+from googleapiclient.errors import HttpError
+import webbrowser
+import io
+
+# need creds.json to work
+
+# If modifying these scopes, delete the file token.json.
+SCOPES = ["https://www.googleapis.com/auth/drive"]
+
+
+def main_test():
+    """Shows basic usage of the Drive v3 API.
+    Prints the names and ids of the first 10 files the user has access to.
+    """
+    webbrowser.register("brave", None, webbrowser.BackgroundBrowser("/usr/bin/brave"))
+
+    creds = None
+    # The file token.json stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    if os.path.exists("token.json"):
+        creds = Credentials.from_authorized_user_file("token.json", SCOPES)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                "creds.json", SCOPES
+            )
+            creds = flow.run_local_server(port=0, browser="brave")
+    # Save the credentials for the next run
+    with open("token.json", "w") as token:
+        token.write(creds.to_json())
+
+    try:
+        # create drive api client
+        service = build("drive", "v3", credentials=creds)
+        files = []
+        page_token = None
+        while True:
+            # pylint: disable=maybe-no-member
+            response = (
+                service.files()
+                .list(
+                    pageSize = 10,
+                    q="visibility = 'limited'",
+                    spaces="drive",
+                    fields="nextPageToken, files(id, name)",
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+            for file in response.get("files", []):
+                # Process change
+                print(f'Found file: {file.get("name")}, {file.get("id")}')
+            files.extend(response.get("files", []))
+            page_token = response.get("nextPageToken", None)
+            # if page_token is None:
+            break
+
+    except HttpError as error:
+        print(f"An error occurred: {error}")
+        files = None
+
+def main():
+    webbrowser.register("brave", None, webbrowser.BackgroundBrowser("/usr/bin/brave"))
+
+    creds = None
+    # The file token.json stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    if os.path.exists("token.json"):
+        creds = Credentials.from_authorized_user_file("token.json", SCOPES)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                "creds.json", SCOPES
+            )
+            creds = flow.run_local_server(port=0, browser="brave")
+    # Save the credentials for the next run
+    with open("token.json", "w") as token:
+        token.write(creds.to_json())
+
+    folder = get_folder(creds)
+    print("Uploading to folder ", folder)
+
+    upload_database(creds, [folder])
+
+    fetch_database(creds, folder)
+    
+
+def overwrite_database(creds: Credentials, parent: str = None):
+    """
+    Overwrite the database if already exists
+    """
+    try:
+        service = build("drive", "v3", credentials = creds)
+        
+        query = f"name = 'passwords.db' and trashed = false and '{parent}' in parents"
+        result: dict = (
+            service.files()
+            .list(fields = "files(id)", q = query)
+            .execute()
+        )
+
+        if not result.get('files'):
+            print("Could not find anything")
+            return False
+    
+        if os.path.exists('passwords.db'):
+            media = MediaFileUpload("passwords.db")
+        else:
+            print("File does not exist, skipping...")
+            return False
+        service.files().update(fileId = result.get('files')[0]['id'], media_body = media).execute()
+
+        print("Done!")
+        return True
+        
+
+    except HttpError as error:
+        print(f"error: {error}")
+
+
+
+def upload_database(creds: Credentials, parents: list[str] = None):
+    """
+    Inserts passwords.db into a folder called "texpass" on Google Drive
+
+    Ensure creds are loaded before calling this
+    """
+
+    if overwrite_database(creds, parents[0]):
+        return
+
+    try:
+        service = build("drive", "v3", credentials = creds)
+        
+        file_metadata = {"name": "passwords.db", "parents": parents}
+        if os.path.exists('passwords.db'):
+            media = MediaFileUpload("passwords.db")
+        else:
+            print("File does not exist, skipping...")
+            return False
+
+        file = service.files().create(body=file_metadata, media_body=media, fields='id').execute()
+        print(f"file id: {file.get("id")}")
+        
+
+    except HttpError as error:
+        print(f"error: {error}")
+
+
+def get_folder(creds: Credentials, name: str = "texpass") -> str:
+    """
+    Get file ID for the folder to save the passwords.db file to
+    """
+    try:
+        service: Resource = build("drive", "v3", credentials=creds)
+        
+        # get a folder which is not shared with anyone or domain
+        # make sure its not a trash folder
+        results: dict = (
+            service.files()
+            .list(fields = "files(parents, id)", q = f"mimeType = 'application/vnd.google-apps.folder' and name = '{name}' and trashed = false")
+            .execute()
+        )
+
+        folders = results.get("files")
+        
+        if not folders:
+            print("No folder found.")
+            return
+        
+        return folders[0]['id']
+    
+    except HttpError as error:
+        # TODO(developer) - Handle errors from drive API.
+        print(f"An error occurred: {error}")
+
+
+def fetch_database(creds: Credentials, parent: str):
+    try:
+        service = build("drive", "v3", credentials=creds)
+        query = f"name = 'passwords.db' and trashed = false and '{parent}' in parents"
+        result: dict = (
+            service.files()
+            .list(fields = "files(id)", q = query)
+            .execute()
+        )
+
+        if not result.get('files'):
+            print("No file exists. Upload before fetching")
+            return
+        else:
+            fileId = result.get('files')[0]['id']
+    
+        results = service.files().get_media(fileId = fileId)
+        file = io.BytesIO()
+
+        downloader = MediaIoBaseDownload(file, results)
+        done = False
+
+        while done is False:
+            status, done = downloader.next_chunk()
+            print(f"Download {int(status.progress() * 100)}.")
+
+    except HttpError as error:
+        print(f"An error occurred: {error}")
+        file = None
+        return
+
+    with open('passwords.db', 'wb') as test:
+        test.write(file.getvalue())
+
+    return file
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Fixes #6

The process is a bit cumbersome to set it up, and it is a bit risky if backing up/fetching down isn't handled properly, as files are overwritten in either cases.

Process to make it work:
- Setup a google cloud project
- Get client credentials from the cloud project ([docs here](https://developers.google.com/workspace/drive/api/quickstart/python#authorize_credentials_for_a_desktop_application))
- Add desired google drive email as a tester, so OAuth works for the user (need 100+ users using the project otherwise. Clearly wasn't meant for individuals doing this).
- Get the creds.json and store it wherever you call texpass from in the command line
- Run `texpass --cloud` to setup access

Everything should work here on.

Now, the features it brings:
- Upload database under texpass folder in Google drive, overwriting `passwords.db` if it exists
- Download database from texpass folder in Google drive, and overwrite existing `passwords.db`

So you may notice how it can be risky. If you accidentally download database while you have a more recent version locally, you'll lose those changes, and vice-versa. So responsibility of the user to upload after changes and download if changes made on another device, before making more changes

**Also need to make sure creds.json and token.json (access token created when setting up drive access) are private and not shared**

This needs to be worked on in the future so it is encrypted.